### PR TITLE
Send GraphQL requests with access token

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "tabWidth": 2
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-dom": "^16.8.1",
     "react-redux": "^6.0.0",
     "redux": "^4.0.1",
+    "reselect": "^4.0.0",
     "resolve": "1.6.0",
     "source-map-loader": "^0.2.1",
     "style-loader": "0.19.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "fs-extra": "7.0.1",
     "html-webpack-plugin": "2.29.0",
     "jest": "20.0.4",
+    "js-cookie": "^2.2.0",
+    "lodash-es": "^4.17.11",
     "object-assign": "4.1.1",
     "postcss-flexbugs-fixes": "3.2.0",
     "postcss-loader": "2.0.8",
@@ -58,6 +60,8 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.0",
+    "@types/js-cookie": "^2.2.0",
+    "@types/lodash-es": "^4.17.1",
     "@types/node": "^10.12.24",
     "@types/react": "^16.8.2",
     "@types/react-dom": "^16.8.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "tslint-react": "^3.2.0",
     "typescript-fsa": "^3.0.0-beta-2",
     "typescript-fsa-reducers": "^1.2.0",
+    "typescript-fsa-redux-thunk": "^1.0.1",
     "uglifyjs-webpack-plugin": "1.2.5",
     "url-loader": "0.6.2",
     "webpack": "3.8.1",

--- a/src/@types/typescript-fsa-redux-thunk.d.ts
+++ b/src/@types/typescript-fsa-redux-thunk.d.ts
@@ -1,0 +1,24 @@
+import { Dispatch } from 'redux';
+import { ThunkAction } from 'redux-thunk';
+import { ThunkActionCreators } from 'typescript-fsa';
+declare module 'typescript-fsa' {
+  interface ThunkActionCreators<State, P, S, E>
+    extends AsyncActionCreators<P, S, E> {}
+  interface ActionCreatorFactory {
+    async<S, P, R, E>(
+      prefix?: string,
+      commonMeta?: Meta,
+    ): ThunkActionCreators<S, P, R, E>;
+  }
+}
+export declare type Thunk<R, S> = ThunkAction<Promise<R>, S, any, any>;
+export declare type AsyncWorker<R, P, S, T = any> = (
+  params: P,
+  dispatch: Dispatch<any>,
+  getState: () => S,
+  extra: T,
+) => Promise<R>;
+export declare const bindThunkAction: <S, P, R, E, T>(
+  asyncAction: ThunkActionCreators<S, P, R, E>,
+  worker: AsyncWorker<R, P, S, T>,
+) => (params: P) => ThunkAction<Promise<R>, S, T, any>;

--- a/src/helpers/Auth.ts
+++ b/src/helpers/Auth.ts
@@ -1,0 +1,12 @@
+import * as Cookies from 'js-cookie';
+
+const GITHUB_ACCESS_TOKEN_COOKIE_NAME = 'GITHUB_ACCESS_TOKEN_COOKIE_NAME';
+
+export class Auth {
+  public static setAccessToken(token: string) {
+    return Cookies.set(GITHUB_ACCESS_TOKEN_COOKIE_NAME, token);
+  }
+  public static getAccessToken() {
+    return Cookies.get(GITHUB_ACCESS_TOKEN_COOKIE_NAME);
+  }
+}

--- a/src/helpers/GithubApi.ts
+++ b/src/helpers/GithubApi.ts
@@ -1,0 +1,33 @@
+import { isUndefined, omitBy } from 'lodash-es';
+import { Auth } from './Auth';
+
+const GITHUB_GRAPHQL_ENDPOINT = 'https://api.github.com/graphql';
+
+const enum Method {
+  POST = 'post',
+}
+
+const defaultHeaders: () => HeadersInit = () => {
+  const accessToken = Auth.getAccessToken();
+  return omitBy(
+    {
+      Authorization: accessToken ? `bearer ${accessToken}` : undefined,
+    },
+    isUndefined,
+  );
+};
+
+const buildPayload = (options: RequestInit) => ({
+  ...options,
+  headers: {
+    ...defaultHeaders(),
+    ...options.headers,
+  },
+  method: Method.POST,
+});
+
+export default class GithubApi {
+  public static call(query: string, options: RequestInit = {}) {
+    return fetch(GITHUB_GRAPHQL_ENDPOINT, buildPayload(options));
+  }
+}

--- a/src/state/queryBrowser/actions.ts
+++ b/src/state/queryBrowser/actions.ts
@@ -1,4 +1,5 @@
 import { bindThunkAction } from 'typescript-fsa-redux-thunk';
+import GithubApi from '../../helpers/GithubApi';
 import types from './types';
 
 export const postQueryRequest = bindThunkAction(
@@ -6,7 +7,9 @@ export const postQueryRequest = bindThunkAction(
   async ({ query }, _dispatch) => {
     // tslint:disable-next-line:no-console
     console.log(query);
-    await new Promise(resolve => setTimeout(resolve, 3000));
+    const res = await GithubApi.call(query);
+    // tslint:disable-next-line:no-console
+    console.log(res);
     return { query };
   },
 );

--- a/src/state/queryBrowser/actions.ts
+++ b/src/state/queryBrowser/actions.ts
@@ -6,6 +6,7 @@ export const postQueryRequest = bindThunkAction(
   async ({ query }, _dispatch) => {
     // tslint:disable-next-line:no-console
     console.log(query);
+    await new Promise(resolve => setTimeout(resolve, 3000));
     return { query };
   },
 );

--- a/src/state/queryBrowser/actions.ts
+++ b/src/state/queryBrowser/actions.ts
@@ -1,0 +1,13 @@
+import { bindThunkAction } from 'typescript-fsa-redux-thunk';
+import types from './types';
+
+export const postQueryRequest = bindThunkAction(
+  types.postQuery,
+  async ({ query }, _dispatch) => {
+    // tslint:disable-next-line:no-console
+    console.log(query);
+    return { query };
+  },
+);
+
+export default { postQueryRequest };

--- a/src/state/queryBrowser/actions.ts
+++ b/src/state/queryBrowser/actions.ts
@@ -2,8 +2,24 @@ import { bindThunkAction } from 'typescript-fsa-redux-thunk';
 import GithubApi from '../../helpers/GithubApi';
 import types from './types';
 
-export const postQueryRequest = bindThunkAction(
-  types.postQuery,
+import { actionCreatorFactory } from 'typescript-fsa';
+const actionCreator = actionCreatorFactory();
+
+interface PostQueryParams {
+  query: string;
+}
+interface PostQueryPayload {
+  query: string;
+}
+
+export const postQuery = actionCreator.async<
+  PostQueryParams,
+  PostQueryPayload,
+  Error
+>(types.POST_QUERY);
+
+const postQueryRequest = bindThunkAction(
+  postQuery,
   async ({ query }, _dispatch) => {
     // tslint:disable-next-line:no-console
     console.log(query);

--- a/src/state/queryBrowser/index.ts
+++ b/src/state/queryBrowser/index.ts
@@ -1,6 +1,7 @@
 import { reducers } from './reducers';
 
-export { default as queryBrowserOperations } from './operations';
 export { initialState } from './reducers';
+export { default as queryBrowserOperations } from './operations';
+export { default as queryBrowserSelectors } from './selectors';
 
 export default reducers;

--- a/src/state/queryBrowser/index.ts
+++ b/src/state/queryBrowser/index.ts
@@ -1,0 +1,6 @@
+import { reducers } from './reducers';
+
+export { default as queryBrowserOperations } from './operations';
+export { initialState } from './reducers';
+
+export default reducers;

--- a/src/state/queryBrowser/operations.ts
+++ b/src/state/queryBrowser/operations.ts
@@ -1,0 +1,5 @@
+import actions from './actions';
+
+export default {
+  postQueryRequest: actions.postQueryRequest,
+};

--- a/src/state/queryBrowser/reducers.ts
+++ b/src/state/queryBrowser/reducers.ts
@@ -14,7 +14,7 @@ export const reducers = reducerWithInitialState<State>(initialState)
     ...state,
     isPostingQuery: true,
   }))
-  .cases([types.postQuery.failed, types.postQuery.failed], state => ({
+  .cases([types.postQuery.failed, types.postQuery.done], state => ({
     ...state,
     isPostingQuery: false,
   }));

--- a/src/state/queryBrowser/reducers.ts
+++ b/src/state/queryBrowser/reducers.ts
@@ -1,0 +1,20 @@
+import { reducerWithInitialState } from 'typescript-fsa-reducers';
+import types from './types';
+
+interface State {
+  isPostingQuery: boolean;
+}
+
+export const initialState = {
+  isPostingQuery: false,
+};
+
+export const reducers = reducerWithInitialState<State>(initialState)
+  .case(types.postQuery.started, state => ({
+    ...state,
+    isPostingQuery: true,
+  }))
+  .cases([types.postQuery.failed, types.postQuery.failed], state => ({
+    ...state,
+    isPostingQuery: false,
+  }));

--- a/src/state/queryBrowser/reducers.ts
+++ b/src/state/queryBrowser/reducers.ts
@@ -1,5 +1,5 @@
 import { reducerWithInitialState } from 'typescript-fsa-reducers';
-import types from './types';
+import { postQuery } from './actions';
 
 interface State {
   isPostingQuery: boolean;
@@ -10,11 +10,11 @@ export const initialState = {
 };
 
 export const reducers = reducerWithInitialState<State>(initialState)
-  .case(types.postQuery.started, state => ({
+  .case(postQuery.started, state => ({
     ...state,
     isPostingQuery: true,
   }))
-  .cases([types.postQuery.failed, types.postQuery.done], state => ({
+  .cases([postQuery.failed, postQuery.done], state => ({
     ...state,
     isPostingQuery: false,
   }));

--- a/src/state/queryBrowser/selectors.ts
+++ b/src/state/queryBrowser/selectors.ts
@@ -1,0 +1,13 @@
+import { createSelector } from 'reselect';
+import { RootState } from '../store';
+
+const getQueryBrowserFromStore = (store: RootState) => store.queryBrowser;
+
+const getIsPostingQuery = createSelector(
+  getQueryBrowserFromStore,
+  queryBrowser => queryBrowser.isPostingQuery,
+);
+
+export default {
+  getIsPostingQuery,
+};

--- a/src/state/queryBrowser/types.ts
+++ b/src/state/queryBrowser/types.ts
@@ -1,0 +1,22 @@
+import { actionCreatorFactory } from 'typescript-fsa';
+
+const enum actions {
+  POST_QUERY = 'POST_QUERY',
+}
+
+const actionCreator = actionCreatorFactory();
+
+interface PostQueryParams {
+  query: string;
+}
+interface PostQueryPayload {
+  query: string;
+}
+
+const postQuery = actionCreator.async<PostQueryParams, PostQueryPayload, Error>(
+  actions.POST_QUERY,
+);
+
+export default {
+  postQuery,
+};

--- a/src/state/queryBrowser/types.ts
+++ b/src/state/queryBrowser/types.ts
@@ -1,22 +1,4 @@
-import { actionCreatorFactory } from 'typescript-fsa';
-
-const enum actions {
+const enum types {
   POST_QUERY = 'POST_QUERY',
 }
-
-const actionCreator = actionCreatorFactory();
-
-interface PostQueryParams {
-  query: string;
-}
-interface PostQueryPayload {
-  query: string;
-}
-
-const postQuery = actionCreator.async<PostQueryParams, PostQueryPayload, Error>(
-  actions.POST_QUERY,
-);
-
-export default {
-  postQuery,
-};
+export default types;

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,0 +1,19 @@
+import { applyMiddleware, combineReducers, createStore } from 'redux';
+import reduxThunk from 'redux-thunk';
+import queryBrowser, {
+  initialState as queryBrowserState,
+} from './queryBrowser';
+
+const rootReducer = combineReducers({
+  queryBrowser,
+});
+
+const initialState: ReturnType<typeof rootReducer> = {
+  queryBrowser: queryBrowserState,
+};
+
+const enhancer = applyMiddleware(reduxThunk);
+
+export const configureStore = () => {
+  return createStore(rootReducer, initialState, enhancer);
+};

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -8,7 +8,9 @@ const rootReducer = combineReducers({
   queryBrowser,
 });
 
-const initialState: ReturnType<typeof rootReducer> = {
+export type RootState = ReturnType<typeof rootReducer>;
+
+const initialState: RootState = {
   queryBrowser: queryBrowserState,
 };
 

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import CardBrowser from './containers/CardBrowser';
 
 import logoSvg from '../assets/logo.svg';
 import './App.css';
@@ -11,9 +12,7 @@ class App extends React.Component {
           <img src={logoSvg} className="App-logo" alt="logo" />
           <h1 className="App-title">Welcome to React</h1>
         </header>
-        <p className="App-intro">
-          To get started, edit <code>src/App.tsx</code> and save to reload.
-        </p>
+        <CardBrowser />
       </div>
     );
   }

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -1,21 +1,23 @@
 import * as React from 'react';
+import { Provider } from 'react-redux';
+import { configureStore } from '../state/store';
 import CardBrowser from './containers/CardBrowser';
 
 import logoSvg from '../assets/logo.svg';
 import './App.css';
 
-class App extends React.Component {
-  public render() {
-    return (
-      <div className="App">
-        <header className="App-header">
-          <img src={logoSvg} className="App-logo" alt="logo" />
-          <h1 className="App-title">Welcome to React</h1>
-        </header>
-        <CardBrowser />
-      </div>
-    );
-  }
-}
+const store = configureStore();
+
+const App: React.FC = () => (
+  <Provider store={store}>
+    <div className="App">
+      <header className="App-header">
+        <img src={logoSvg} className="App-logo" alt="logo" />
+        <h1 className="App-title">Welcome to React</h1>
+      </header>
+      <CardBrowser />
+    </div>
+  </Provider>
+);
 
 export default App;

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
 import { configureStore } from '../state/store';
+import ConfigurationForm from './components/ConfigurationForm';
 import CardBrowser from './containers/CardBrowser';
 
 import logoSvg from '../assets/logo.svg';
@@ -15,6 +16,7 @@ const App: React.FC = () => (
         <img src={logoSvg} className="App-logo" alt="logo" />
         <h1 className="App-title">Welcome to React</h1>
       </header>
+      <ConfigurationForm />
       <CardBrowser />
     </div>
   </Provider>

--- a/src/views/components/ConfigurationForm.tsx
+++ b/src/views/components/ConfigurationForm.tsx
@@ -1,0 +1,25 @@
+import IconButton from '@material-ui/core/IconButton';
+import TextField from '@material-ui/core/TextField';
+import { default as SettingsIcon } from '@material-ui/icons/Settings';
+import * as React from 'react';
+import { Auth } from '../../helpers/Auth';
+
+const ConfigurationForm: React.FC = () => {
+  const [value, setValue] = React.useState(Auth.getAccessToken());
+  return (
+    <form noValidate={true} autoComplete="off">
+      <TextField
+        label="Access Token"
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        margin="normal"
+        variant="outlined"
+      />
+      <IconButton onClick={() => Auth.setAccessToken(value || '')}>
+        <SettingsIcon />
+      </IconButton>
+    </form>
+  );
+};
+
+export default ConfigurationForm;

--- a/src/views/components/QueryForm.tsx
+++ b/src/views/components/QueryForm.tsx
@@ -7,8 +7,10 @@ interface Props {
   onSubmit: (query: string) => void;
 }
 
+const defaultQuery = 'is:issue is:open';
+
 const QueryForm: React.FC<Props> = props => {
-  const [value, setValue] = React.useState('');
+  const [value, setValue] = React.useState(defaultQuery);
   return (
     <form noValidate={true} autoComplete="off">
       <TextField

--- a/src/views/components/QueryForm.tsx
+++ b/src/views/components/QueryForm.tsx
@@ -1,0 +1,28 @@
+import IconButton from '@material-ui/core/IconButton';
+import TextField from '@material-ui/core/TextField';
+import { default as SearchIcon } from '@material-ui/icons/Search';
+import * as React from 'react';
+
+interface Props {
+  onSubmit: (query: string) => void;
+}
+
+const QueryForm: React.FC<Props> = props => {
+  const [value, setValue] = React.useState('');
+  return (
+    <form noValidate={true} autoComplete="off">
+      <TextField
+        label="Query"
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        margin="normal"
+        variant="outlined"
+      />
+      <IconButton onClick={() => props.onSubmit(value)}>
+        <SearchIcon />
+      </IconButton>
+    </form>
+  );
+};
+
+export default QueryForm;

--- a/src/views/containers/CardBrowser.tsx
+++ b/src/views/containers/CardBrowser.tsx
@@ -1,14 +1,24 @@
 import * as React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators, Dispatch } from 'redux';
+import { queryBrowserOperations } from '../../state/queryBrowser';
 import QueryForm from '../components/QueryForm';
 
-// tslint:disable-next-line:no-empty-interface
-interface Props {}
+type Props = ReturnType<typeof mapDispatchToProps>;
 
 interface State {
   queries: string[];
 }
 
-export default class CardBrowser extends React.Component<Props, State> {
+const mapDispatchToProps = (dispatch: Dispatch) =>
+  bindActionCreators(
+    {
+      postQueryRequest: queryBrowserOperations.postQueryRequest,
+    },
+    dispatch,
+  );
+
+class CardBrowser extends React.Component<Props, State> {
   public constructor(props: Props) {
     super(props);
     this.state = { queries: [] };
@@ -20,7 +30,9 @@ export default class CardBrowser extends React.Component<Props, State> {
       <div>
         <QueryForm onSubmit={this.registerQuery} />
         {this.state.queries.map(q => (
-          <p>{q}</p>
+          <p onClick={() => this.props.postQueryRequest({ query: q }) && true}>
+            {q}
+          </p>
         ))}
       </div>
     );
@@ -30,3 +42,8 @@ export default class CardBrowser extends React.Component<Props, State> {
     this.setState({ queries: [...this.state.queries, query] });
   }
 }
+
+export default connect(
+  null,
+  mapDispatchToProps,
+)(CardBrowser);

--- a/src/views/containers/CardBrowser.tsx
+++ b/src/views/containers/CardBrowser.tsx
@@ -40,8 +40,13 @@ class CardBrowser extends React.Component<Props, State> {
       <div>
         <p>{this.props.isPostingQuery ? 'true' : 'false'}</p>
         <QueryForm onSubmit={this.registerQuery} />
-        {this.state.queries.map(q => (
-          <p onClick={() => this.props.postQueryRequest({ query: q })}>{q}</p>
+        {this.state.queries.map((q, index) => (
+          <p
+            key={index}
+            onClick={() => this.props.postQueryRequest({ query: q })}
+          >
+            {q}
+          </p>
         ))}
       </div>
     );

--- a/src/views/containers/CardBrowser.tsx
+++ b/src/views/containers/CardBrowser.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import QueryForm from '../components/QueryForm';
+
+// tslint:disable-next-line:no-empty-interface
+interface Props {}
+
+interface State {
+  queries: string[];
+}
+
+export default class CardBrowser extends React.Component<Props, State> {
+  public constructor(props: Props) {
+    super(props);
+    this.state = { queries: [] };
+    this.registerQuery = this.registerQuery.bind(this);
+  }
+
+  public render() {
+    return (
+      <div>
+        <QueryForm onSubmit={this.registerQuery} />
+        {this.state.queries.map(q => (
+          <p>{q}</p>
+        ))}
+      </div>
+    );
+  }
+
+  private registerQuery(query: string) {
+    this.setState({ queries: [...this.state.queries, query] });
+  }
+}

--- a/src/views/containers/CardBrowser.tsx
+++ b/src/views/containers/CardBrowser.tsx
@@ -1,14 +1,24 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
-import { queryBrowserOperations } from '../../state/queryBrowser';
+import {
+  queryBrowserOperations,
+  queryBrowserSelectors,
+} from '../../state/queryBrowser';
+import { RootState } from '../../state/store';
 import QueryForm from '../components/QueryForm';
 
-type Props = ReturnType<typeof mapDispatchToProps>;
+type DispatchProps = ReturnType<typeof mapDispatchToProps>;
+type StateProps = ReturnType<typeof mapStateToProps>;
+type Props = StateProps & DispatchProps;
 
 interface State {
   queries: string[];
 }
+
+const mapStateToProps = (store: RootState) => ({
+  isPostingQuery: queryBrowserSelectors.getIsPostingQuery(store),
+});
 
 const mapDispatchToProps = (dispatch: Dispatch) =>
   bindActionCreators(
@@ -28,11 +38,10 @@ class CardBrowser extends React.Component<Props, State> {
   public render() {
     return (
       <div>
+        <p>{this.props.isPostingQuery ? 'true' : 'false'}</p>
         <QueryForm onSubmit={this.registerQuery} />
         {this.state.queries.map(q => (
-          <p onClick={() => this.props.postQueryRequest({ query: q }) && true}>
-            {q}
-          </p>
+          <p onClick={() => this.props.postQueryRequest({ query: q })}>{q}</p>
         ))}
       </div>
     );
@@ -44,6 +53,6 @@ class CardBrowser extends React.Component<Props, State> {
 }
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps,
 )(CardBrowser);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,10 @@
     "importHelpers": true,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "paths": {
+      "*": ["src/@types/*"]
+    }
   },
   "exclude": [
     "node_modules",

--- a/tslint.json
+++ b/tslint.json
@@ -49,7 +49,7 @@
       "allow-pascal-case"
     ],
     "no-implicit-dependencies": false,
-    "no-submodule-imports": [true],
+    "no-submodule-imports": [true, "@material-ui/core", "@material-ui/icons"],
     "object-literal-sort-keys": false
   },
   "linterOptions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5419,6 +5419,11 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+lodash-es@^4.2.1:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
+  integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==
+
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -5489,7 +5494,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0:
+"lodash@>=3.5 <5", lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -7347,6 +7352,21 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
+redux-thunk@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
+redux@^3.7.0:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
+  integrity sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==
+  dependencies:
+    lodash "^4.2.1"
+    lodash-es "^4.2.1"
+    loose-envify "^1.1.0"
+    symbol-observable "^1.0.3"
+
 redux@^4.0.0, redux@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
@@ -8319,7 +8339,7 @@ sw-toolbox@^3.4.0:
     path-to-regexp "^1.0.1"
     serviceworker-cache-polyfill "^4.0.0"
 
-symbol-observable@1.2.0, symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
+symbol-observable@1.2.0, symbol-observable@^1.0.3, symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
@@ -8690,6 +8710,21 @@ typescript-fsa-reducers@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/typescript-fsa-reducers/-/typescript-fsa-reducers-1.2.0.tgz#015043b22440ce517e696f24564f7233b6a5a67b"
   integrity sha512-JGIqBDf4SV+pE8CDenTqtr13cts7kwS3/YbYhLoKZZMZWSIhwn+xwwbrg/oEfvftLykyE9PXrySy6A62m6gEaw==
+
+typescript-fsa-redux-thunk@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/typescript-fsa-redux-thunk/-/typescript-fsa-redux-thunk-1.0.1.tgz#ca7cfa0dd582960cec00c622efdbc787b3c58d4b"
+  integrity sha512-+im3ewRmuuJK5ygLFpFkqT/mHrcI9PaGk8IKnuZ5kHIyk6jTtBSXPBbBg7yB/x8mXIcAU1zMBcsiNJBw4WaTuA==
+  dependencies:
+    redux "^3.7.0"
+    redux-thunk "^2.2.0"
+    tslib "^1.7.1"
+    typescript-fsa "^2.3.0"
+
+typescript-fsa@^2.3.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/typescript-fsa/-/typescript-fsa-2.5.0.tgz#1baec01b5e8f5f34c322679d1327016e9e294faf"
+  integrity sha1-G67AG16PXzTDImedEycBbp4pT68=
 
 typescript-fsa@^3.0.0-beta-2:
   version "3.0.0-beta-2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7564,6 +7564,11 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,6 +109,11 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.0.tgz#848492026c327b3548d92be0352a545c36a21e8a"
   integrity sha512-kOafJnUTnMd7/OfEO/x3I47EHswNjn+dbz9qk3mtonr1RvKT+1FGVxnxAx08I9K8Tl7j9hpoJRE7OCf+t10fng==
 
+"@types/js-cookie@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.0.tgz#ae2eabaa4bc892ba553c664cca21e6ee5224e5b5"
+  integrity sha512-k0umv2jvUvl1/OdOgFwEIPF6qKllf2jEsrd5ka9aVQo2ilxaBb2vsh1AmAAZ3eqt54vNrdbGW5QPOKJBmCNS7g==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -121,6 +126,18 @@
   dependencies:
     csstype "^2.0.0"
     indefinite-observable "^1.0.1"
+
+"@types/lodash-es@^4.17.1":
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.1.tgz#56745e5411558362aeca31def918f88f725dd29d"
+  integrity sha512-3EDZjphPfdjnsWvY11ufYImFMPyQJwIH1eFYRgWQsjOctce06fmNgVf5sfvXBRiaS1o0X50bAln1lfWs8ZO3BA==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.120"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.120.tgz#cf265d06f6c7a710db087ed07523ab8c1a24047b"
+  integrity sha512-jQ21kQ120mo+IrDs1nFNVm/AsdFxIx2+vZ347DbogHJPd/JzKNMOqU6HCYin1W6v8l5R9XSO2/e9cxmn7HAnVw==
 
 "@types/node@^10.12.24":
   version "10.12.24"
@@ -5046,6 +5063,11 @@ js-base64@^2.1.9:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.1.tgz#1efa39ef2c5f7980bb1784ade4a8af2de3291121"
   integrity sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==
 
+js-cookie@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
+  integrity sha1-Gywnmm7s44ChIWi5JIUmWzWx7/s=
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -5419,7 +5441,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.2.1:
+lodash-es@^4.17.11, lodash-es@^4.2.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
   integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==


### PR DESCRIPTION
## changes
- introduce four libraries
  - `js-cookie` cookie API wrapper
  - `lodash-es` handy utilities 
  - `typescript-fsa-redux-thunk` async action helper
  - `reselect` selector layer cache
- add a monkey patch to `typescript-fsa-redux-thunk.d.ts`
  - seems`ThunkActionCreator`'s type definition is wrong
- follow the `re-ducks` design pattern
  - ref. https://github.com/alexnm/re-ducks